### PR TITLE
Added filtlong down-sampling of long reads to avoid time over-runs.

### DIFF
--- a/app_specs/GenomeAssembly2.json
+++ b/app_specs/GenomeAssembly2.json
@@ -141,9 +141,9 @@
       "type": "boolean"
     },
     {
-      "default": 100,
+      "default": 200,
       "desc": "Target depth for BBNorm and Filtlong",
-      "id": "targetDepth",
+      "id": "target_depth",
       "label": "target_depth",
       "required": 0,
       "type": "int"

--- a/app_specs/GenomeAssembly2.json
+++ b/app_specs/GenomeAssembly2.json
@@ -141,10 +141,26 @@
       "type": "boolean"
     },
     {
+      "default": 100,
+      "desc": "Target depth for BBNorm and Filtlong",
+      "id": "targetDepth",
+      "label": "target_depth",
+      "required": 0,
+      "type": "int"
+    },
+    {
       "default": false,
       "desc": "Normalize reads using BBNorm before assembly",
       "id": "normalize",
       "label": "normalize_reads",
+      "required": 0,
+      "type": "boolean"
+    },
+    {
+      "default": false,
+      "desc": "Filter long reads on length and quality to target depth",
+      "id": "filtlong",
+      "label": "filter_long_reads",
       "required": 0,
       "type": "boolean"
     },
@@ -165,12 +181,12 @@
       "type": "float"
     },
     {
-      "default": "5M",
-      "desc": "Estimated genome size (for canu)",
+      "default": 5000000,
+      "desc": "Estimated genome size (used for canu and flye and filtlong)",
       "id": "genome_size",
       "label": "Genome Size",
       "required": 0,
-      "type": "string"
+      "type": "int"
     },
     {
       "default": null,

--- a/scripts/p3x-assembly.py
+++ b/scripts/p3x-assembly.py
@@ -1217,7 +1217,7 @@ def main():
     parser.add_argument('--trim', action='store_true', help='trim reads with trim_galore at default settings')
     parser.add_argument('--normalize', action='store_true', help='normalize read depth with BBNorm at default settings')
     parser.add_argument('--filtlong', action='store_true', help='filter long reads on quality, length and a proxy for accuracy using filtlong')
-    parser.add_argument('--targetDepth', type=int, default=100, help='downsample to this approx. coverage')
+    parser.add_argument('--target_depth', type=int, default=200, help='downsample to this approx. coverage')
     parser.add_argument('--filtlong_pct', type=int, default=90, help='pct long reads to keep after filtering on quality, length and accuracy using filtlong')
     parser.add_argument('--pilon_jar', help='path to pilon executable or jar')
     parser.add_argument('--canu_exec', default="canu", help='path to canu executable (def "canu")')
@@ -1354,7 +1354,7 @@ def main():
 
     if args.normalize:
         for read_set in short_reads:
-            read_set.normalize_read_depth(target_depth = args.targetDepth)
+            read_set.normalize_read_depth(target_depth = args.target_depth)
 
     if args.filtlong and len(long_reads):
         LOG.write(f"args.filtlong is set")
@@ -1364,7 +1364,7 @@ def main():
                 illumina_reference = read_set
                 LOG.write(f"selected illumina reference for filtlong: {illumina_reference}\n")
         for read_set in long_reads:
-            target_bases = args.genome_size * args.targetDepth
+            target_bases = args.genome_size * args.target_depth
             read_set.filter_long_reads(target_bases, illumina_reference, args.filtlong_pct)
 
     if args.max_bases:

--- a/service-scripts/App-GenomeAssembly2.pl
+++ b/service-scripts/App-GenomeAssembly2.pl
@@ -243,6 +243,13 @@ sub assemble
 	push(@params, '--filtlong');
     }
 
+    # Target depth for down-sampling by bbnorm and/or filtlong
+    #
+    if ($params->{target_depth})
+    {
+	push(@params, '--target_depth', $params->{target_depth});
+    }
+
     #
     # Contig filtering options
     #

--- a/service-scripts/App-GenomeAssembly2.pl
+++ b/service-scripts/App-GenomeAssembly2.pl
@@ -236,6 +236,13 @@ sub assemble
 	push(@params, '--normalize');
     }
 
+    # We use filtlong here.
+    #
+    if ($params->{filtlong})
+    {
+	push(@params, '--filtlong');
+    }
+
     #
     # Contig filtering options
     #


### PR DESCRIPTION
Filtlong program needs to be on path (https://github.com/rrwick/Filtlong)
This program filters out reads based on a score combining length and quality, removing the worst ones to achieve target depth.
Both filtlong and normalize should be checkboxes (default on) in the UI (advenced parameters).

Added --target_depth parameter (defaults to 200)
Note: this is not exposed on the UI. So it should remain at default until we decide it needs to be used.

If --filtlong is specified, then each long read file is down-sampled to (target_depth * genome_size) bases.

If --normalize is specified, then bbnorm.sh is used to normalize to target_depth coverage.

--genome_size is used to calculate target number of bases for filtlong, and passed to canu and flye.

App-spec changed a bit (genome size is now an integer instead of string; filtlong flag is added).